### PR TITLE
Add memory limiter flag

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 print_help_exit() {
     echo "Usage: "$0" debug|release [rtos||bare]"
@@ -17,7 +18,6 @@ copy_all_files() {
 copy_freertos_files() {
     # will overwrite the previous copied files
     cp ../bilsv3-libraries/internal/iotc_bsp/iotc_bsp_mem_freertos.c src/bsp/platform/bilsv/iotc_bsp_mem_bilsv.c
-    cp ../bilsv3-libraries/internal/iotc_bsp/iotc_bsp_io_net_freertos.c src/bsp/platform/bilsv/iotc_bsp_io_net_bilsv.c
 }
 
 # Wipe the folder clean to avoid clashing FreeRTOS with non-FreeRTOS c files from previous run

--- a/make/mt-config/mt-presets.mk
+++ b/make/mt-config/mt-presets.mk
@@ -30,7 +30,7 @@ CONFIG_DUMMY_MIN           =memory_fs
 
 # CONFIG for BILSV3
 # no tls and no fs
-CONFIG_BILSV3			   =tls_socket-dummy_fs
+CONFIG_BILSV3			   =tls_socket-dummy_fs-memory_limiter
 
 # TARGET presets
 TARGET_STATIC_DEV          =-static-debug


### PR DESCRIPTION
This is required when turning on the batch telemetry in bils firmware.