### PR TITLE
update library reference

### DIFF
--- a/make/mt-os/mt-bilsv.mk
+++ b/make/mt-os/mt-bilsv.mk
@@ -11,7 +11,7 @@ IOTC_FREERTOS_DIR_INCLUDES += -I$(IOTC_FREERTOS_DIR_PATH)/Source/portable/GCC/CM
 MY_BUILD_PROJECT_PATH=$(LIBIOTC)/../../bike.cydsn
 CRYPTO_AUTH_LIB_PATH=$(LIBIOTC)/third_party/cryptoauthlib/lib
 INTERNAL_LIB_PATH=$(LIBIOTC)/../bilsv3-libraries/internal
-PROTOBUF_LIB_PATH=$(LIBIOTC)/../basis-libraries/messaging/c/output
+PROTOBUF_LIB_PATH=$(LIBIOTC)/../basis-messaging/messaging/c/output
 NANOPB_LIB_PATH=$(LIBIOTC)/../bilsv3-libraries/external/nanopb
 
 #build positional independent code for the library


### PR DESCRIPTION
In the past, backend + FW jointly used the protobuf file defined in `basis-libraries`. Lately the backend has moved to use the protobuf file in `basis-messaging`.
So updating to build against the protobuf file in `basis-messaging`.